### PR TITLE
Catch exception on colormap re-registering

### DIFF
--- a/src/pythonprop/voaP2PPlot.py
+++ b/src/pythonprop/voaP2PPlot.py
@@ -137,7 +137,10 @@ class VOAP2PPlot:
         self.image_defs = self.IMG_TYPE_DICT[self.data_type]
         self.user_bands = user_bands
         portland = ListedColormap(["#0C3383", "#0b599b","#0a7fb4","#57a18f","#bec255","#f2c438","#f2a638","#ef8235","#e4502a","#d91e1e"])
-        matplotlib.cm.register_cmap(name='portland', cmap=portland)
+        try:
+            matplotlib.cm.register_cmap(name='portland', cmap=portland)
+        except ValueError:
+            print("Portland colormap is already registered")
 
         if plot_groups[0]=='a':
             num_grp = self.df.get_number_of_groups()


### PR DESCRIPTION
When trying to plot graphics in voaP2PPlot.py a second time, a ValueError exception was raised.

This patch catches this Exception, allowing the user to plot the graphics whenever needed.