### PR TITLE
Set matplotlib backend during initialization

### DIFF
--- a/src/pythonprop/voaAreaPlot.py
+++ b/src/pythonprop/voaAreaPlot.py
@@ -114,6 +114,9 @@ class VOAAreaPlot:
 
         self.datadir = datadir
 
+        # set backend during initialization to avoid switching error
+        matplotlib.use('GTK3Agg')
+
         try:
             plot_parameters = VOAFile((in_file))
             plot_parameters.parse_file()

--- a/src/pythonprop/voaP2PPlot.py
+++ b/src/pythonprop/voaP2PPlot.py
@@ -136,6 +136,10 @@ class VOAP2PPlot:
 
         self.image_defs = self.IMG_TYPE_DICT[self.data_type]
         self.user_bands = user_bands
+
+        # set backend during initialization to avoid switching error
+        matplotlib.use('GTK3Agg')
+
         portland = ListedColormap(["#0C3383", "#0b599b","#0a7fb4","#57a18f","#bec255","#f2c438","#f2a638","#ef8235","#e4502a","#d91e1e"])
         matplotlib.cm.register_cmap(name='portland', cmap=portland)
 


### PR DESCRIPTION
On Debian 12, an error was caused  when trying to plot the graphs in both the voaAreaPlot.py and voaP2PPlot.py ("ImportError: Cannot load backend 'TkAgg' which requires the 'tk' interactive framework, as 'gtk3' is currently running").

This patch initializes the backend for matplotlib explicitly during object initialization, avoiding the problem.