### PR TITLE
Add Keywords field to .desktop file

### DIFF
--- a/data/voacapgui.desktop.in
+++ b/data/voacapgui.desktop.in
@@ -3,4 +3,5 @@ Type=Application
 Exec=voacapgui
 Name=voacapgui
 Categories=Science;HamRadio
+Keywords=amateur;ham;hf;prediction;plot;radio;voacap;
 Icon=@PACKAGE@


### PR DESCRIPTION
The Keywords field is used by several Freedesktop-compliant desktop environment and "software centers" to allow users to find applications by typing in keywords related in some way to the desired software.

This makes pythonprop more discoverable by end-users.