### PR TITLE
Avoid invalid Python escape sequences

### DIFF
--- a/src/pythonprop/templates/area_userdefined.py
+++ b/src/pythonprop/templates/area_userdefined.py
@@ -59,7 +59,7 @@ class templates:
 
     def load(self):
         if not self.area_templates_file: return -1
-        re_tag_name = re.compile('\[(.*)\]')
+        re_tag_name = re.compile(r'\[(.*)\]')
         fd = None
         try:
             fd = open(os.path.expandvars(self.area_templates_file))

--- a/src/pythonprop/voaAntennaChooser.py
+++ b/src/pythonprop/voaAntennaChooser.py
@@ -84,7 +84,7 @@ class VOAAntennaChooser:
             testLine = f.readline()
             f.close()
             if (testLine.find("parameters") == 9):
-                antenna_description = re.sub('\s+', ' ', antenna_description)
+                antenna_description = re.sub(r'\s+', ' ', antenna_description)
                 antenna_file = os.path.relpath(antenna_file, self.antenna_path)
                 if len(antenna_file) > 21:
                     err_msg_body = "The file path ('{:s}')\nis too long and should be less than 21 characters.\n\nPlease rename the antenna file.".format(antenna_file)

--- a/src/pythonprop/voaSiteChooser.py
+++ b/src/pythonprop/voaSiteChooser.py
@@ -144,7 +144,7 @@ class VOASiteChooser:
         #sm.set_select_function(self.geo_tv_selected, False) # todo pygobject check this (it's just a guess)
         sm.connect("changed", self.geo_tv_selected)
         
-        self.alpha_numeric_re = re.compile('[\W_]+')
+        self.alpha_numeric_re = re.compile(r'[\W_]+')
         self.latitude_column = 0
         self.longitude_column = 0
          

--- a/src/pythonprop/voacapgui.py
+++ b/src/pythonprop/voacapgui.py
@@ -98,8 +98,8 @@ class VOACAP_GUI():
     # Determine where the itshfbc and prefs files are, based on OS
     # The windows paths are guesses and need checking....
     if os.name == 'nt':
-        itshfbc_path = 'C:\itshfbc'
-        prefs_dir = 'C:\itshfbc\database\\'
+        itshfbc_path = r'C:\itshfbc'
+        prefs_dir = r'C:\itshfbc\database' + '\\'
     else:
         itshfbc_path = os.path.expanduser("~")+os.sep+'itshfbc'
         prefs_dir = os.path.expanduser("~")+os.sep+'.voacapgui'+os.sep


### PR DESCRIPTION
When installing the program on Debian 12, there were some warnings about the usage of invalid Python escape sequences on some lines, mostly related to regular expressions and Windows paths.

This patch avoids those cases by using Python raw strings instead.