### PR TITLE
Add missing manpages

### DIFF
--- a/man/voa3DPlot.1
+++ b/man/voa3DPlot.1
@@ -1,0 +1,36 @@
+.TH voa3DPlot 1 "FEV 2024" Linux "User Manuals"
+.SH NAME
+voa3DPlot \- Plot the contents of VOACAP output files in a 3D format
+.SH SYNOPSIS
+.B voa3DPlot [options] file
+.SH DESCRIPTION
+.B voa3DPlot
+A python script used to graphically display the contents of output files produced by VOACAP.
+.SH OPTIONS
+.IP --version
+Shows program version number and exit.
+.IP "-h, --help"
+Shows a help message and exit.
+.IP "-b band, --band=band"
+Displays a band plan indicated by 'band', an integer value from 1 to 3 (1:SWL, 2:UK AMATEUR BANDS and 3:KSA AMATEUR BANDS).
+.IP "-f max_frequency, --freqmax=max_frequency"
+Specifies the maximum frequency (MHz) to display on the Y axis.
+.IP "-g group, --group=group"
+Specifies the group(s) within a file containing multiple groups to plot.  Multiple groups must be separated by commas, e.g. '-g 1,3,4' (default = 1).
+.IP "-l 'label', --label='label'"
+Specifies the text label to be printed as a main title at the top of the plot.
+.IP "-m colourmap, --cmap=colourmap"
+Specifies the colourmap to use. Supported colour maps are 'autumn', 'bone', 'cool', 'copper',', 'hot', 'hsv', 'jet', 'pink', 'spring', 'summer', 'winter' (default = 'jet').
+.IP "-o outputfile, --outfile=outputfile"
+Used to specify an output file to save the plot to.
+.IP "-q, --quiet"
+Process quietly, don't produce a graph on the screen.  This only makes sense when used in conjunction with the -o option.
+.IP "-t type, --datatype=type"
+Specifies the type of image to plot.  Supported image types are 0:None 1:MUFday 2:REL 3:SNR 4:S DBW (default = 1).
+.IP "-z timezone, --timezone=timezone"
+Specifies the timezone to shift the plots to.
+.SH AUTHORS
+This program was written by James Watson (M0DNS) <jimwatson at mac dot com>.
+
+This manual page was written by David da Silva Polverari <polverari@debian.org>
+for the Debian Project (but may be used by others).

--- a/man/voaAreaPlotgui.1
+++ b/man/voaAreaPlotgui.1
@@ -1,0 +1,13 @@
+.TH voaAreaPlotgui 1 "FEV 2024" Linux "User Manuals"
+.SH NAME
+voaAreaPlotgui \- Graphical frontend to the voaAreaPlot application
+.SH SYNOPSIS
+.B voaAreaPlotgui file
+.SH DESCRIPTION
+.B voaAreaPlotgui
+is a graphical user interface to the voaAreaPlot application. It plots the file contents according to the parameters set on the user interface.
+.SH AUTHORS
+This program was written by James Watson (M0DNS) <jimwatson at mac dot com>.
+
+This manual page was written by David da Silva Polverari <polverari@debian.org>
+for the Debian Project (but may be used by others).

--- a/man/voaP2PPlotgui.1
+++ b/man/voaP2PPlotgui.1
@@ -1,0 +1,13 @@
+.TH voaP2PPlotgui 1 "FEV 2024" Linux "User Manuals"
+.SH NAME
+voaP2PPlotgui \- Graphical frontend to the voaP2PPlot application
+.SH SYNOPSIS
+.B voaP2PPlotgui file
+.SH DESCRIPTION
+.B voaP2PPlotgui
+is a graphical user interface to the voaP2PPlot application. It plots the file contents according to the parameters set on the user interface.
+.SH AUTHORS
+This program was written by James Watson (M0DNS) <jimwatson at mac dot com>.
+
+This manual page was written by David da Silva Polverari <polverari@debian.org>
+for the Debian Project (but may be used by others).

--- a/man/voacapgui.1
+++ b/man/voacapgui.1
@@ -1,0 +1,13 @@
+.TH voacapgui 1 "FEV 2024" Linux "User Manuals"
+.SH NAME
+voacapgui \- An input GUI for voacapl
+.SH SYNOPSIS
+.B voacapgui
+.SH DESCRIPTION
+.B voacapgui
+is a graphical user interface frontend for \fBvoacapl\fP. It generates voacap input files from user input data and plots the resulting predictions.
+.SH AUTHORS
+This program was written by James Watson (M0DNS) <jimwatson at mac dot com>.
+
+This manual page was written by David da Silva Polverari <polverari@debian.org>
+for the Debian Project (but may be used by others).


### PR DESCRIPTION
There were missing manpages to some of the software executables. Some distributions, such as Debian, consider it a bug not having manpages to programs that are not auxiliary ones.

This commit provides the same manpages that were written for the Debian packaging of pythonprop, in the hope they will be useful as a starting point for an official manpage (or used "as is", if deemed so), if there is interest in implementing them.