### PR TITLE
Fix manpage warnings caused by troff

### DIFF
--- a/man/voaAreaPlot.1
+++ b/man/voaAreaPlot.1
@@ -46,7 +46,7 @@ POI_FILE is a text file with points of interest to plot on the map.  The file is
 .IP "-p PROJECTION, --projection=PROJECTION"
 PROJECTION specifies the map projection.  Valid values are 'cyl' (Equidistant
 Cylindrical), 'mill' (Miller Cylindrical), gall' (Gall Stereographic),
-'robin' (Robinson), 'vandg' (van der Grinten), 'sinu' (Sinusoidal), 'mbtfpq'
+\(aqrobin' (Robinson), 'vandg' (van der Grinten), 'sinu' (Sinusoidal), 'mbtfpq'
 (McBryde-Thomas Flat Polar Quartic), 'eck4' (Eckert IV), 'kav7' (Kavrayskiy
 VII), 'moll' (Mollweide), 'hammer' (Hammer).
 .IP "-r RESOLUTION, --resolution=RESOLUTION"


### PR DESCRIPTION
troff treats lines starting with an apostrophe as a control line, that can be followed by a macro call. This caused a warning when packaging pythonprop for Debian.

This patch fixes the problem by using \(aq instead of an apostrophe on the beginning of the line.