### PR TITLE
Fix working with Matplotlib 3.9

### DIFF
--- a/data/voacapgui.desktop
+++ b/data/voacapgui.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
-Version=1.0
 Type=Application
 Exec=voacapgui
 Name=voacapgui
-Categories=Science;HamRadio;
-Icon=pythonprop.png
+Categories=Science;HamRadio
+Keywords=amateur;ham;hf;prediction;plot;radio;voacap;
+Icon=pythonprop

--- a/src/pythonprop/voaAreaPlot.py
+++ b/src/pythonprop/voaAreaPlot.py
@@ -208,7 +208,7 @@ class VOAAreaPlot:
                     cbar_mode='single',
                     cbar_pad=0.2,
                     cbar_size='3%',
-                    label_mode='')
+                    label_mode='L')
         
         self.main_title_label = fig.suptitle(str(self.image_defs['title']), fontsize=self.main_title_fontsize)
 

--- a/src/pythonprop/voaAreaPlot.py
+++ b/src/pythonprop/voaAreaPlot.py
@@ -292,7 +292,7 @@ class VOAAreaPlot:
                     ax.plot([xpt],[ypt],'ro')
                     ax.text(xpt+100000,ypt+100000,location.get_name())
             """
-            gl = ax.gridlines(crs=projection, draw_labels=True,
+            gl = ax.gridlines(crs=projection, draw_labels=["bottom", "left"],
                   linewidth=1, color='black', alpha=0.75)
             gl.xlabels_top = False
             gl.xlabels_bottom = False

--- a/src/pythonprop/voaAreaPlot.py
+++ b/src/pythonprop/voaAreaPlot.py
@@ -156,7 +156,7 @@ class VOAAreaPlot:
         colMap = color_map
 
         projection = ccrs.PlateCarree()
-        axes_class = (GeoAxes,dict(map_projection=projection))
+        axes_class = (GeoAxes,dict(projection=projection))
 
         number_of_subplots = len(vg_files)
 

--- a/src/pythonprop/voaAreaPlot.py
+++ b/src/pythonprop/voaAreaPlot.py
@@ -148,9 +148,9 @@ class VOAAreaPlot:
         #    print "-180 < Latitude < 180.0, -90 < Longitude < 90"
         #    sys.exit(1)
 
-        portland = ListedColormap(["#0C3383", "#0b599b","#0a7fb4","#57a18f","#bec255","#f2c438","#f2a638","#ef8235","#e4502a","#d91e1e"])
+        portland = ListedColormap(["#0C3383","#0b599b","#0a7fb4","#57a18f","#bec255","#f2c438","#f2a638","#ef8235","#e4502a","#d91e1e"], name="portland")
         try:
-            plt.register_cmap(name='portland', cmap=portland)
+            matplotlib.colormaps.register(cmap=portland)
         except ValueError:
             print("Portland colormap is already registered")
         colMap = color_map

--- a/src/pythonprop/voaP2PPlot.py
+++ b/src/pythonprop/voaP2PPlot.py
@@ -140,9 +140,10 @@ class VOAP2PPlot:
         # set backend during initialization to avoid switching error
         matplotlib.use('GTK3Agg')
 
-        portland = ListedColormap(["#0C3383", "#0b599b","#0a7fb4","#57a18f","#bec255","#f2c438","#f2a638","#ef8235","#e4502a","#d91e1e"])
+        portland = ListedColormap(["#0C3383", "#0b599b","#0a7fb4","#57a18f","#bec255","#f2c438","#f2a638","#ef8235","#e4502a","#d91e1e"],
+name="portland")
         try:
-            matplotlib.cm.register_cmap(name='portland', cmap=portland)
+            matplotlib.colormaps.register(cmap=portland)
         except ValueError:
             print("Portland colormap is already registered")
 

--- a/src/pythonprop/voaP2PPlot.py
+++ b/src/pythonprop/voaP2PPlot.py
@@ -204,7 +204,7 @@ name="portland")
                     cbar_mode='single',
                     cbar_pad=0.2,
                     cbar_size='3%',
-                    label_mode='')
+                    label_mode='L')
 
         self.main_title_label = fig.suptitle(plot_label+str(self.image_defs['title']), fontsize=self.main_title_fontsize)
 


### PR DESCRIPTION
Starting with matplotlib-3.9 voacapgui fails to draw diagrams for P2P and Area plots with following problems:

- register_cmap() do no longer exist
- AxesGrid() does no longer allow an empty label_mode parameter

After fixing it shows that diagrams in Area plot have grid label on all four sides.

The provided PR fixes these problems and take care of some deprecation warning for GeoAxes projection.